### PR TITLE
test: break e2e tests into e2e-test feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,9 @@ zip = {version = "0.6.2", default-features = false, features = ["deflate"]}
 [target.'cfg(unix)'.dependencies]
 exec = "0.3.1"
 
+[features]
+test-e2e = [] # run e2e tests
+
 [dev-dependencies]
 test-case = "2.2.1"
 rand = "0.8.5"

--- a/src/cli/checksums.rs
+++ b/src/cli/checksums.rs
@@ -66,6 +66,7 @@ async fn fetch_checksum(filename: &Path, platform: &str) -> Result<String> {
 }
 
 #[cfg(test)]
+#[cfg(feature = "test-e2e")]
 mod tests {
     use super::*;
     use pretty_assertions::assert_eq;

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -28,6 +28,7 @@ pub async fn run(args: Vec<String>) -> Result<()> {
 }
 
 #[cfg(test)]
+#[cfg(feature = "test-e2e")]
 mod tests {
     use super::*;
     use std::fs::File;


### PR DESCRIPTION
this way we can potentially skip them and only run the unit tests